### PR TITLE
Using custom user to run Apache on container

### DIFF
--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -6,15 +6,20 @@ LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
 # Make necessary directories
 RUN mkdir -p /etc/apache2/ssl
-RUN mkdir -p /var/www/simplerisk
+
+# Creating Simplerisk user on www-data group
+RUN useradd -G www-data simplerisk
 
 # Installing apt dependencies
 RUN apt-get update && apt-get -y dist-upgrade && apt-get -y install libmcrypt-dev \
                                                                     libldap2-dev \
                                                                     pwgen \
+                                                                    libcap2-bin \
                                                                     sendmail \
                                                                     mariadb-client \
                                                                     supervisor
+# Quickly run setcap to allow port
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2
 # Run configure for certain extensions
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu
 # Install extensions
@@ -26,7 +31,7 @@ RUN docker-php-ext-install ldap \
 # Installing mcrypt through pecl and enabling it
 RUN yes | pecl install mcrypt-1.0.1 && docker-php-ext-enable mcrypt
 # Performing a cleanup
-RUN apt-get -y autoremove && apt-get -y purge && rm -rf /var/lib/apt/lists/*
+RUN apt-get -y remove libcap2-bin && apt-get -y autoremove && apt-get -y purge && rm -rf /var/lib/apt/lists/*
 
 # Create the OpenSSL password
 RUN pwgen -cn 20 1 > /tmp/pass_openssl.txt
@@ -65,8 +70,9 @@ RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers
 # Download and extract SimpleRisk
 RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` \
     && curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version
-RUN chown -R www-data:www-data /var/www/simplerisk
-RUN chmod -R 770 /var/www/simplerisk
+
+# Running necessary ownerships
+RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run /var/log/apache2 && chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2
 
 # Ports to expose
 EXPOSE 80

--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -84,12 +84,10 @@ RUN chmod 755 /start.sh
 
 # Data to save
 VOLUME /var/log
-VOLUME /var/lib/mysql
 VOLUME /etc/apache2/ssl
 VOLUME /var/www/simplerisk
 
 # Creating user to avoid root
-RUN adduser -D -G simplerisk www-data
 USER simplerisk 
 
 # Start Apache 

--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -65,7 +65,8 @@ RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers
 # Download and extract SimpleRisk
 RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` \
     && curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version
-RUN chown -R www-data: /var/www/simplerisk
+RUN chown -R www-data:www-data /var/www/simplerisk
+RUN chmod -R 770 /var/www/simplerisk
 
 # Ports to expose
 EXPOSE 80
@@ -80,6 +81,10 @@ VOLUME /var/log
 VOLUME /var/lib/mysql
 VOLUME /etc/apache2/ssl
 VOLUME /var/www/simplerisk
+
+# Creating user to avoid root
+RUN adduser -D -G simplerisk www-data
+USER simplerisk 
 
 # Start Apache 
 CMD ["/bin/bash", "/start.sh"]

--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -72,7 +72,7 @@ RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep 
     && curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version
 
 # Running necessary ownerships
-RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run /var/log/apache2 && chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2
+RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2
 
 # Ports to expose
 EXPOSE 80

--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -65,8 +65,6 @@ RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mod
 RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
 RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
-RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers
-
 # Download and extract SimpleRisk
 RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` \
     && curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version

--- a/simplerisk-php7.2-apache/app_setup/envvars
+++ b/simplerisk-php7.2-apache/app_setup/envvars
@@ -13,7 +13,7 @@ fi
 # Since there is no sane way to get the parsed apache2 config in scripts, some
 # settings are defined via environment variables and then used in apache2ctl,
 # /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
-export APACHE_RUN_USER=www-data
+export APACHE_RUN_USER=simplerisk
 export APACHE_RUN_GROUP=www-data
 export APACHE_PID_FILE=/var/run/apache2$SUFFIX.pid
 export APACHE_RUN_DIR=/var/run/apache2$SUFFIX


### PR DESCRIPTION
Originally, the container runs as root. As a measure of securing containers to avoid root access, a user has been created for that purpose (simplerisk). It will run Apache in a rootless mode.