### PR TITLE
Using Entrypoint to run previous scripts

### DIFF
--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -72,13 +72,9 @@ RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep 
 # Running necessary ownerships
 RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2
 
-# Ports to expose
-EXPOSE 80
-EXPOSE 443
-
 # Create the start script and set permissions
-COPY ./app_setup/start.sh /start.sh
-RUN chmod 755 /start.sh
+COPY ./app_setup/entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
 
 # Data to save
 VOLUME /var/log
@@ -88,5 +84,12 @@ VOLUME /var/www/simplerisk
 # Creating user to avoid root
 USER simplerisk 
 
+# Setting up entrypoint
+ENTRYPOINT [ "/start.sh" ]
+
+# Ports to expose
+EXPOSE 80
+EXPOSE 443
+
 # Start Apache 
-CMD ["/bin/bash", "/start.sh"]
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -72,7 +72,7 @@ RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep 
 # Running necessary ownerships
 RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2
 
-# Create the start script and set permissions
+# Create the entrypoint script and set permissions
 COPY ./app_setup/entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
@@ -85,7 +85,7 @@ VOLUME /var/www/simplerisk
 USER simplerisk 
 
 # Setting up entrypoint
-ENTRYPOINT [ "/start.sh" ]
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 # Ports to expose
 EXPOSE 80

--- a/simplerisk-php7.2-apache/app_setup/entrypoint.sh
+++ b/simplerisk-php7.2-apache/app_setup/entrypoint.sh
@@ -92,7 +92,7 @@ _main() {
     if [ ! -z $FIRST_TIME_SETUP ]; then
       db_setup
     fi
-    /usr/sbin/apache2ctl -D FOREGROUND
+    exec "$@"
 }
 
 _main

--- a/simplerisk-php7.2-apache/app_setup/entrypoint.sh
+++ b/simplerisk-php7.2-apache/app_setup/entrypoint.sh
@@ -95,4 +95,4 @@ _main() {
     exec "$@"
 }
 
-_main
+_main "$@"


### PR DESCRIPTION
Previously, a CMD instruction was set to run the script. Now, it is using an ENTRYPOINT to run previous scripts before running the main apache command.