### PR TITLE
Generating random passwords for first time setups

### DIFF
--- a/simplerisk-php7.2-apache/app_setup/entrypoint.sh
+++ b/simplerisk-php7.2-apache/app_setup/entrypoint.sh
@@ -41,7 +41,7 @@ set_config(){
     if [ ! -z $FIRST_TIME_SETUP ]; then
         if [ -z $SIMPLERISK_DB_PASSWORD ]; then
             SIMPLERISK_DB_PASSWORD=$(pwgen -cn 20 1)
-            echo "As no password was provided and this is a first time setup, a random password has been generated ($(echo $SIMPLERISK_DB_PASSWORD))"
+            print_log "initial_setup:warn" "As no password was provided and this is a first time setup, a random password has been generated ($(echo $SIMPLERISK_DB_PASSWORD))"
         fi
         sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
     else
@@ -66,19 +66,19 @@ set_config(){
 }
 
 db_setup(){
-    print_log "info" "First time setup. Will wait..."
+    print_log "initial_setup:info" "First time setup. Will wait..."
     exec_cmd "sleep $(echo ${FIRST_TIME_SETUP_WAIT:-2O})s > /dev/null 2>&1" "FIRST_TIME_SETUP_WAIT variable is set incorrectly. Exiting."
 
-    print_log "info" "Starting database set up"
+    print_log "initial_setup:info" "Starting database set up"
 
-    print_log "info" "Downloading schema..."
+    print_log "initial_setup:info" "Downloading schema..."
     SCHEMA_FILE='/tmp/simplerisk.sql'
     exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-$(cat /tmp/version).sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
 
     FIRST_TIME_SETUP_USER="${FIRST_TIME_SETUP_USER:-root}"
     FIRST_TIME_SETUP_PASS="${FIRST_TIME_SETUP_PASS:-root}"
 
-    print_log "info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
+    print_log "initial_setup:info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
     exec_cmd "mysql --protocol=socket -u $FIRST_TIME_SETUP_USER -p$FIRST_TIME_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
     CREATE DATABASE ${SIMPLERISK_DB_DATABASE};
     USE ${SIMPLERISK_DB_DATABASE};
@@ -87,10 +87,10 @@ db_setup(){
     GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON ${SIMPLERISK_DB_DATABASE}.* TO ${SIMPLERISK_DB_USERNAME}@'%';
 EOSQL" "Was not able to apply settings on database. Check error above. Exiting."
 
-    print_log "info" "Setup has been applied successfully!"
+    print_log "initial_setup:info" "Setup has been applied successfully!"
 
     if [ ! -z $FIRST_TIME_SETUP_ONLY ]; then
-        print_log "info" "Running on setup only. Container will be discarded."
+        print_log "initial_setup:info" "Running on setup only. Container will be discarded."
         exit 0
     fi
 }

--- a/simplerisk-php7.2-apache/app_setup/entrypoint.sh
+++ b/simplerisk-php7.2-apache/app_setup/entrypoint.sh
@@ -24,48 +24,56 @@ set_config(){
 
     # Replacing config variables if they exist
     if [ ! -z $SIMPLERISK_DB_HOSTNAME ]; then
-        sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1`echo $SIMPLERISK_DB_HOSTNAME`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_HOSTNAME)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_HOSTNAME="${SIMPLERISK_DB_HOSTNAME:-localhost}"
 
     if [ ! -z $SIMPLERISK_DB_PORT ]; then
-        sed -i "s/\('DB_PORT', '\).*\(');\)/\1`echo $SIMPLERISK_DB_PORT`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_PORT', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PORT)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_PORT="${SIMPLERISK_DB_PORT:-3306}"
 
     if [ ! -z $SIMPLERISK_DB_USERNAME ]; then
-        sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1`echo $SIMPLERISK_DB_USERNAME`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_USERNAME)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_USERNAME="${SIMPLERISK_DB_USERNAME:-simplerisk}"
 
-    if [ ! -z $SIMPLERISK_DB_PASSWORD ]; then
-        sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1`echo $SIMPLERISK_DB_PASSWORD`\2/g" $CONFIG_PATH
+    if [ ! -z $FIRST_TIME_SETUP ]; then
+        if [ -z $SIMPLERISK_DB_PASSWORD ]; then
+            SIMPLERISK_DB_PASSWORD=$(pwgen -cn 20 1)
+            echo "As no password was provided and this is a first time setup, a random password has been generated ($(echo $SIMPLERISK_DB_PASSWORD))"
+        fi
+        sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
+    else
+        if [ ! -z $SIMPLERISK_DB_PASSWORD ]; then
+            sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
+        fi
     fi
-    SIMPLERISK_DB_PASSWORD="${SIMPLERISK_DB_PASSWORD:-simplerisk}"
+    SIMPLERISK_DB_PASSWORD="${SIMPLERISK_DB_PASSWORD:-simplerisk}" 
 
     if [ ! -z $SIMPLERISK_DB_DATABASE ]; then
-        sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1`echo $SIMPLERISK_DB_DATABASE`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_DATABASE)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_DATABASE="${SIMPLERISK_DB_DATABASE:-simplerisk}"
 
     if [ ! -z $SIMPLERISK_DB_FOR_SESSIONS ]; then
-        sed -i "s/\('USE_DATABASE_FOR_SESSIONS', '\).*\(');\)/\1`echo $SIMPLERISK_DB_FOR_SESSIONS`\2/g" $CONFIG_PATH
+        sed -i "s/\('USE_DATABASE_FOR_SESSIONS', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_FOR_SESSIONS)\2/g" $CONFIG_PATH
     fi
 
     if [ ! -z $SIMPLERISK_DB_SSL_CERT_PATH ]; then
-        sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1`echo $SIMPLERISK_DB_SSL_CERT_PATH`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_SSL_CERT_PATH)\2/g" $CONFIG_PATH
     fi
 }
 
 db_setup(){
     print_log "info" "First time setup. Will wait..."
-    exec_cmd "sleep `echo ${FIRST_TIME_SETUP_WAIT:-2O}`s > /dev/null 2>&1" "FIRST_TIME_SETUP_WAIT variable is set incorrectly. Exiting."
+    exec_cmd "sleep $(echo ${FIRST_TIME_SETUP_WAIT:-2O})s > /dev/null 2>&1" "FIRST_TIME_SETUP_WAIT variable is set incorrectly. Exiting."
 
     print_log "info" "Starting database set up"
 
     print_log "info" "Downloading schema..."
     SCHEMA_FILE='/tmp/simplerisk.sql'
-    exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-`cat /tmp/version`.sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
+    exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-$(cat /tmp/version).sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
 
     FIRST_TIME_SETUP_USER="${FIRST_TIME_SETUP_USER:-root}"
     FIRST_TIME_SETUP_PASS="${FIRST_TIME_SETUP_PASS:-root}"


### PR DESCRIPTION
When the user is setting up the database and no password is specified for the simplerisk database (`SIMPLERISK_DB_PASSWORD`), the application would use the `config.php` default (`simplerisk`).

To make a more secure process, in case the user is setting up the database and is not specifying the database password, then the application will generate a random one, to avoid using random values and to respect the current official Docker image setup.