### PR TITLE
Creating leaner and readable Dockerfile image

### DIFF
--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -4,6 +4,8 @@ FROM php:7.2-apache
 # Maintained by SimpleRisk
 LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
+WORKDIR /var/www
+
 # Installing apt dependencies
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
@@ -48,7 +50,7 @@ RUN pwgen -cn 20 1 > /tmp/pass_openssl.txt
 RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key
 RUN openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
 RUN openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
-RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key
+RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt
 RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
 RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
 # Activate Apache modules
@@ -59,20 +61,23 @@ RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mod
 RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
 RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
-# Download and extract SimpleRisk
-RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` && \
-    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version
+# Download and extract SimpleRisk, plus saving version for database reference
+RUN rm -rf /var/www/html && \
+    VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && \
+    echo $VERSION > /tmp/version && \
+    mv simplerisk html
 
 # Creating Simplerisk user on www-data group and setting up ownerships
 RUN useradd -G www-data simplerisk
-RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
-    chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+RUN chown -R simplerisk:www-data /var/www/html /etc/apache2 /var/run/ /var/log/apache2 && \
+    chmod -R 770 /var/www/html /etc/apache2 /var/run/ /var/log/apache2 && \
     chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
 
 # Data to save
 VOLUME /var/log/apache2
 VOLUME /etc/apache2/ssl
-VOLUME /var/www/simplerisk
+VOLUME /var/www/html
 
 # Using simplerisk user from here 
 USER simplerisk 

--- a/simplerisk-php7.2-apache/Dockerfile
+++ b/simplerisk-php7.2-apache/Dockerfile
@@ -4,59 +4,53 @@ FROM php:7.2-apache
 # Maintained by SimpleRisk
 LABEL maintainer="Simplerisk <support@simplerisk.com>"
 
-# Make necessary directories
-RUN mkdir -p /etc/apache2/ssl
-
-# Creating Simplerisk user on www-data group
-RUN useradd -G www-data simplerisk
-
 # Installing apt dependencies
-RUN apt-get update && apt-get -y dist-upgrade && apt-get -y install libmcrypt-dev \
-                                                                    libldap2-dev \
-                                                                    pwgen \
-                                                                    libcap2-bin \
-                                                                    sendmail \
-                                                                    mariadb-client \
-                                                                    supervisor
-# Quickly run setcap to allow port
-RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2
-# Run configure for certain extensions
-RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu
-# Install extensions
-RUN docker-php-ext-install ldap \
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y install libmcrypt-dev \
+                       libldap2-dev \
+                       pwgen \
+                       libcap2-bin \
+                       sendmail \
+                       mariadb-client \
+                       supervisor
+# Configure all PHP extensions 
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \
+    docker-php-ext-install ldap \
                            mbstring \
                            json \
                            mysqli \
-                           pdo_mysql 
-# Installing mcrypt through pecl and enabling it
-RUN yes | pecl install mcrypt-1.0.1 && docker-php-ext-enable mcrypt
-# Performing a cleanup
-RUN apt-get -y remove libcap2-bin && apt-get -y autoremove && apt-get -y purge && rm -rf /var/lib/apt/lists/*
+                           pdo_mysql && \
+    yes | pecl install mcrypt-1.0.1 && \
+    docker-php-ext-enable mcrypt
+# Setting up setcap for port mapping without root and removing packages 
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \
+    apt-get -y remove libcap2-bin && \
+    apt-get -y autoremove && \
+    apt-get -y purge && \
+    rm -rf /var/lib/apt/lists/*
 
-# Create the OpenSSL password
-RUN pwgen -cn 20 1 > /tmp/pass_openssl.txt
-
-# Configure supervisor
+# Copying all files
 COPY ./app_setup/supervisord.conf /etc/supervisord.conf
-RUN service supervisor restart
-
-# Configure Apache
 COPY ./app_setup/foreground.sh /etc/apache2/foreground.sh
-RUN chmod 755 /etc/apache2/foreground.sh
 COPY ./app_setup/envvars /etc/apache2/envvars
 COPY ./app_setup/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY ./app_setup/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
-RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /usr/local/etc/php/php.ini-production
+COPY ./app_setup/entrypoint.sh /entrypoint.sh
 
+# Start supervisor 
+RUN service supervisor restart
+
+# Configure Apache
+RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /usr/local/etc/php/php.ini-production
 # Create SSL Certificates for Apache SSL
-RUN mkdir -p /etc/apache2/ssl/ssl.crt
-RUN mkdir -p /etc/apache2/ssl/ssl.key
+RUN pwgen -cn 20 1 > /tmp/pass_openssl.txt
+RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key
 RUN openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
 RUN openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
 RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key
 RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
 RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
-
 # Activate Apache modules
 RUN a2enmod rewrite ssl
 RUN a2enconf security
@@ -66,22 +60,21 @@ RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/sec
 RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
 
 # Download and extract SimpleRisk
-RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` \
-    && curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version
+RUN VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && echo $VERSION > /tmp/version
 
-# Running necessary ownerships
-RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2
-
-# Create the entrypoint script and set permissions
-COPY ./app_setup/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+# Creating Simplerisk user on www-data group and setting up ownerships
+RUN useradd -G www-data simplerisk
+RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+    chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+    chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
 
 # Data to save
-VOLUME /var/log
+VOLUME /var/log/apache2
 VOLUME /etc/apache2/ssl
 VOLUME /var/www/simplerisk
 
-# Creating user to avoid root
+# Using simplerisk user from here 
 USER simplerisk 
 
 # Setting up entrypoint

--- a/simplerisk-php7.2-apache/app_setup/default-ssl.conf
+++ b/simplerisk-php7.2-apache/app_setup/default-ssl.conf
@@ -3,8 +3,8 @@
 SSLStrictSNIVHostCheck Off
 
 <VirtualHost *:443>
-        DocumentRoot /var/www/simplerisk
-        <Directory "/var/www/simplerisk">
+        DocumentRoot /var/www/html
+        <Directory "/var/www/html">
                 AllowOverride all
                 allow from all
                 Options -Indexes

--- a/simplerisk-php7.2-apache/app_setup/entrypoint.sh
+++ b/simplerisk-php7.2-apache/app_setup/entrypoint.sh
@@ -20,69 +20,79 @@ fatal_error(){
 }
 
 set_config(){
-    CONFIG_PATH='/var/www/simplerisk/includes/config.php'
+    CONFIG_PATH='/var/www/html/includes/config.php'
 
     # Replacing config variables if they exist
     if [ ! -z $SIMPLERISK_DB_HOSTNAME ]; then
-        sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1`echo $SIMPLERISK_DB_HOSTNAME`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_HOSTNAME)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_HOSTNAME="${SIMPLERISK_DB_HOSTNAME:-localhost}"
 
     if [ ! -z $SIMPLERISK_DB_PORT ]; then
-        sed -i "s/\('DB_PORT', '\).*\(');\)/\1`echo $SIMPLERISK_DB_PORT`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_PORT', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PORT)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_PORT="${SIMPLERISK_DB_PORT:-3306}"
 
     if [ ! -z $SIMPLERISK_DB_USERNAME ]; then
-        sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1`echo $SIMPLERISK_DB_USERNAME`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_USERNAME)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_USERNAME="${SIMPLERISK_DB_USERNAME:-simplerisk}"
 
-    if [ ! -z $SIMPLERISK_DB_PASSWORD ]; then
-        sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1`echo $SIMPLERISK_DB_PASSWORD`\2/g" $CONFIG_PATH
+    if [ ! -z $FIRST_TIME_SETUP ]; then
+        if [ -z $SIMPLERISK_DB_PASSWORD ]; then
+            SIMPLERISK_DB_PASSWORD=$(pwgen -cn 20 1)
+            print_log "initial_setup:warn" "As no password was provided and this is a first time setup, a random password has been generated ($(echo $SIMPLERISK_DB_PASSWORD))"
+        fi
+        sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
+    else
+        if [ ! -z $SIMPLERISK_DB_PASSWORD ]; then
+            sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
+        fi
     fi
-    SIMPLERISK_DB_PASSWORD="${SIMPLERISK_DB_PASSWORD:-simplerisk}"
+    SIMPLERISK_DB_PASSWORD="${SIMPLERISK_DB_PASSWORD:-simplerisk}" 
 
     if [ ! -z $SIMPLERISK_DB_DATABASE ]; then
-        sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1`echo $SIMPLERISK_DB_DATABASE`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_DATABASE)\2/g" $CONFIG_PATH
     fi
     SIMPLERISK_DB_DATABASE="${SIMPLERISK_DB_DATABASE:-simplerisk}"
 
     if [ ! -z $SIMPLERISK_DB_FOR_SESSIONS ]; then
-        sed -i "s/\('USE_DATABASE_FOR_SESSIONS', '\).*\(');\)/\1`echo $SIMPLERISK_DB_FOR_SESSIONS`\2/g" $CONFIG_PATH
+        sed -i "s/\('USE_DATABASE_FOR_SESSIONS', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_FOR_SESSIONS)\2/g" $CONFIG_PATH
     fi
 
     if [ ! -z $SIMPLERISK_DB_SSL_CERT_PATH ]; then
-        sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1`echo $SIMPLERISK_DB_SSL_CERT_PATH`\2/g" $CONFIG_PATH
+        sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_SSL_CERT_PATH)\2/g" $CONFIG_PATH
     fi
 }
 
 db_setup(){
-    print_log "info" "First time setup. Will wait..."
-    exec_cmd "sleep `echo ${FIRST_TIME_SETUP_WAIT:-2O}`s > /dev/null 2>&1" "FIRST_TIME_SETUP_WAIT variable is set incorrectly. Exiting."
+    print_log "initial_setup:info" "First time setup. Will wait..."
+    exec_cmd "sleep $(echo ${FIRST_TIME_SETUP_WAIT:-2O})s > /dev/null 2>&1" "FIRST_TIME_SETUP_WAIT variable is set incorrectly. Exiting."
 
-    print_log "info" "Starting database set up"
+    print_log "initial_setup:info" "Starting database set up"
 
-    print_log "info" "Downloading schema..."
+    print_log "initial_setup:info" "Downloading schema..."
     SCHEMA_FILE='/tmp/simplerisk.sql'
-    exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-`cat /tmp/version`.sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
+    exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-$(cat /tmp/version).sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
 
     FIRST_TIME_SETUP_USER="${FIRST_TIME_SETUP_USER:-root}"
     FIRST_TIME_SETUP_PASS="${FIRST_TIME_SETUP_PASS:-root}"
 
-    print_log "info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
+    print_log "initial_setup:info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
     exec_cmd "mysql --protocol=socket -u $FIRST_TIME_SETUP_USER -p$FIRST_TIME_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
     CREATE DATABASE ${SIMPLERISK_DB_DATABASE};
     USE ${SIMPLERISK_DB_DATABASE};
-    \. /tmp/simplerisk.sql 
+    \. ${SCHEMA_FILE}
     CREATE USER ${SIMPLERISK_DB_USERNAME}@'%' IDENTIFIED BY '${SIMPLERISK_DB_PASSWORD}';
     GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON ${SIMPLERISK_DB_DATABASE}.* TO ${SIMPLERISK_DB_USERNAME}@'%';
 EOSQL" "Was not able to apply settings on database. Check error above. Exiting."
 
-    print_log "info" "Setup has been applied successfully!"
+    print_log "initial_setup:info" "Setup has been applied successfully!"
+    print_log "initial_setup:info" "Removing schema file..."
+    exec_cmd "rm ${SCHEMA_FILE}"
 
     if [ ! -z $FIRST_TIME_SETUP_ONLY ]; then
-        print_log "info" "Running on setup only. Container will be discarded."
+        print_log "initial_setup:info" "Running on setup only. Container will be discarded."
         exit 0
     fi
 }

--- a/simplerisk-php7.2-apache/app_setup/supervisord.conf
+++ b/simplerisk-php7.2-apache/app_setup/supervisord.conf
@@ -138,8 +138,6 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 ;[include]
 ;files = relative/directory/*.ini
 ;mysql and apache2
-[program:mysqld]
-command=/usr/bin/mysqld_safe
 [program:httpd]
 command=/etc/apache2/foreground.sh
 stopsignal=6


### PR DESCRIPTION
This Dockerfile is trying to use the less quantity of RUNs to avoid creating too many layers. Plus, for any run that is executing more than one commands, it is showing them on a new line (with the exception of the package installation, which is separating each packages into new lines).

Also, using ENTRYPOINT to run previous script setup, and using CMD to only run the Apache2 service.