### PR TITLE
Removing SIGKILL and KILL from trap

### DIFF
--- a/simplerisk-php7.2-apache/app_setup/foreground.sh
+++ b/simplerisk-php7.2-apache/app_setup/foreground.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 read pid cmd state ppid pgrp session tty_nr tpgid rest < /proc/self/stat
-trap "kill -TERM -$pgrp; exit" EXIT TERM KILL SIGKILL SIGTERM SIGQUIT
+trap "kill -TERM -$pgrp; exit" EXIT TERM SIGTERM SIGQUIT
 
 
 source /etc/apache2/envvars


### PR DESCRIPTION
This is based on https://github.com/koalaman/shellcheck/wiki/SC2173, which is used for the scanning bash