### PR TITLE
Creating image with PHP 7.4

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -4,21 +4,20 @@ services:
   simplerisk:
     environment:
     # IN CASE YOU WANT TO SETUP FOR THE FIRST TIME,
-    # USE AND ADAPT THESE VARIABLES
-    # - FIRST_TIME_SETUP=1
-    # - FIRST_TIME_SETUP_ONLY=1 # Use only if you want to stop container after startup 
-    # - FIRST_TIME_SETUP_USER=root
-    # - FIRST_TIME_SETUP_PASS=rootpassword
-    # - FIRST_TIME_SETUP_WAIT=10
+    # USE AND ADAPT THE COMMENTED VARIABLES
+    #- FIRST_TIME_SETUP=1
+    #- FIRST_TIME_SETUP_ONLY=1 # Use only if you want to stop container after startup
+    #- FIRST_TIME_SETUP_USER=root
+    #- FIRST_TIME_SETUP_PASS=rootpassword
+    #- FIRST_TIME_SETUP_WAIT=10
     - SIMPLERISK_DB_HOSTNAME=mariadb
     - SIMPLERISK_DB_PASSWORD=samplepassword
-    image: simplerisk/simplerisk:php7.2-apache
+    image: simplerisk/simplerisk:php7.4-apache 
     networks:
     - simplerisk
     ports:
       - "80:80"
       - "443:443"
-    
 
   mariadb:
     command: mysqld --sql_mode="NO_ENGINE_SUBSTITUTION"
@@ -27,8 +26,12 @@ services:
     image: mariadb:10.3
     networks:
     -  simplerisk
-    volumes:
-    - /tmp/mysql-data:/var/lib/mysql
+
+  # Configure to your needs (https://hub.docker.com/r/namshi/smtp)
+  smtp:
+    image: namshi/smtp
+    networks:
+    - simplerisk
 
 networks:
   simplerisk:

--- a/simplerisk-php7.4-apache/Dockerfile
+++ b/simplerisk-php7.4-apache/Dockerfile
@@ -1,0 +1,89 @@
+# Using dedicated PHP image with version 7.4 and Apache
+FROM php:7.4-apache 
+
+# Maintained by SimpleRisk
+LABEL maintainer="Simplerisk <support@simplerisk.com>"
+
+WORKDIR /var/www
+
+# Installing apt dependencies
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y install libldap2-dev \
+                       libcap2-bin \
+                       libonig-dev \
+                       sendmail \
+                       mariadb-client \
+                       supervisor
+# Configure all PHP extensions 
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu && \
+    docker-php-ext-install ldap \
+                           mbstring \
+                           json \
+                           mysqli \
+                           pdo_mysql
+# Setting up setcap for port mapping without root and removing packages 
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2 && \
+    apt-get -y remove libcap2-bin && \
+    apt-get -y autoremove && \
+    apt-get -y purge && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copying all files
+COPY ./app_setup/supervisord.conf /etc/supervisord.conf
+COPY ./app_setup/foreground.sh /etc/apache2/foreground.sh
+COPY ./app_setup/envvars /etc/apache2/envvars
+COPY ./app_setup/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+COPY ./app_setup/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
+COPY ./app_setup/entrypoint.sh /entrypoint.sh
+
+# Start supervisor 
+RUN service supervisor restart
+
+# Configure Apache
+RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 5M/g' /usr/local/etc/php/php.ini-production
+# Create SSL Certificates for Apache SSL
+RUN echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32}) > /tmp/pass_openssl.txt
+RUN mkdir -p /etc/apache2/ssl/ssl.crt /etc/apache2/ssl/ssl.key
+RUN openssl genrsa -des3 -passout pass:/tmp/pass_openssl.txt -out /etc/apache2/ssl/ssl.key/simplerisk.pass.key
+RUN openssl rsa -passin pass:/tmp/pass_openssl.txt -in /etc/apache2/ssl/ssl.key/simplerisk.pass.key -out /etc/apache2/ssl/ssl.key/simplerisk.key
+RUN rm /etc/apache2/ssl/ssl.key/simplerisk.pass.key /tmp/pass_openssl.txt
+RUN openssl req -new -key /etc/apache2/ssl/ssl.key/simplerisk.key -out  /etc/apache2/ssl/ssl.crt/simplerisk.csr -subj "/CN=simplerisk"
+RUN openssl x509 -req -days 365 -in /etc/apache2/ssl/ssl.crt/simplerisk.csr -signkey /etc/apache2/ssl/ssl.key/simplerisk.key -out /etc/apache2/ssl/ssl.crt/simplerisk.crt
+# Activate Apache modules
+RUN a2enmod rewrite ssl
+RUN a2enconf security
+RUN sed -i 's/SSLProtocol all -SSLv3/SSLProtocol TLSv1.2/g' /etc/apache2/mods-enabled/ssl.conf
+RUN sed -i 's/#SSLHonorCipherOrder on/SSLHonorCipherOrder on/g' /etc/apache2/mods-enabled/ssl.conf
+RUN sed -i 's/ServerTokens OS/ServerTokens Prod/g' /etc/apache2/conf-enabled/security.conf
+RUN sed -i 's/#ServerSignature On/ServerSignature Off/g' /etc/apache2/conf-enabled/security.conf
+
+# Download and extract SimpleRisk, plus saving version for database reference
+RUN rm -rf /var/www/html && \
+    VERSION=`curl -sL https://updates.simplerisk.com/Current_Version.xml | grep -oP '<appversion>(.*)</appversion>' | cut -d '>' -f 2 | cut -d '<' -f 1` && \
+    curl -sL https://github.com/simplerisk/bundles/raw/master/simplerisk-$VERSION.tgz | tar xz -C /var/www && \
+    echo $VERSION > /tmp/version
+
+# Creating Simplerisk user on www-data group and setting up ownerships
+RUN useradd -G www-data simplerisk
+RUN chown -R simplerisk:www-data /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+    chmod -R 770 /var/www/simplerisk /etc/apache2 /var/run/ /var/log/apache2 && \
+    chmod 755 /entrypoint.sh /etc/apache2/foreground.sh
+
+# Data to save
+VOLUME /var/log/apache2
+VOLUME /etc/apache2/ssl
+VOLUME /var/www/simplerisk
+
+# Using simplerisk user from here 
+USER simplerisk 
+
+# Setting up entrypoint
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+# Ports to expose
+EXPOSE 80
+EXPOSE 443
+
+# Start Apache 
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/simplerisk-php7.4-apache/Dockerfile
+++ b/simplerisk-php7.4-apache/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
     apt-get -y install libldap2-dev \
                        libcap2-bin \
                        libonig-dev \
-                       sendmail \
                        mariadb-client \
                        supervisor
 # Configure all PHP extensions 

--- a/simplerisk-php7.4-apache/README.md
+++ b/simplerisk-php7.4-apache/README.md
@@ -1,0 +1,67 @@
+# Simplerisk Image
+
+This image runs SimpleRisk into a more microservices approach by using a container based on PHP:7.2-apache and with the specific capability of setting properties of the config.php file through environment variables. A MySQL/MariaDB instance must be created separately (a docker-compose file is provided).
+
+## How to build this image?
+
+Please run the following command according to your container engine:
+- **Docker**: `docker build -t simplerisk/simplerisk:php7.2-apache .`
+- **Podman**: `podman build -t simplerisk/simplerisk:php7.2-apache`
+
+## Ways to run the application
+
+### Set up database
+
+If this is the first time running the application, you need to set up your MySQL/MariaDB database with the SimpleRisk schema. You must provide the environment variables `FIRST_TIME_SETUP`, and optionally provide any of the variables that start with `FIRST_TIME_SETUP_*`. If you want to only set up the database (and discard the container afterwards), use `FIRST_TIME_SETUP_ONLY`. This might be helpful in a setup where you can first configure the database (like a initContainer on Kubernetes) and if the process ran successfully, then execute a new container with SimpleRisk running normally.
+
+Another detail to consider is that if you are running the database setup and the `SIMPLERISK_DB_PASSWORD` variable is not provided, the application will generate a random password. You must check the logs to get it.
+
+### Run the application normally
+
+In this case, as long as the `FIRST_TIME_SETUP` variable is not provided, then the application will run normally, considering only the `SIMPLERISK_*` variables.
+
+## Environment variables
+
+### FIRST_TIME_SETUP
+
+This indicates if the database is going to be set up from zero. This means installing the necessary schema and creating the user, in case there is any setup. Requires `FIRST_TIME_SETUP_USER` and `FIRST_TIME_SETUP_USER_PASS`. As long it is a non-null value, it will run. By default, it assumes everything is already set up.
+
+### FIRST_TIME_SETUP_ONLY
+
+This indicates if the container will only be used to configure the database, and will exit after finishing it. As long it is a non-null value, it will run. By default, it will let the container alive.
+
+### FIRST_TIME_SETUP_USER and FIRST_TIME_SETUP_PASS
+
+Credentials for the privileged user that will be used to install the schema on the database. Default value for both is `root`.
+
+### FIRST_TIME_SETUP_WAIT
+
+This is the time, in seconds, the application is going to wait to set up the installation, in case the database is being loaded at the same time. It works together with `FIRST_TIME_SETUP`. Default value is `20`.
+
+### SIMPLERISK_DB_HOSTNAME
+
+This will replace the content of the DB_HOSTNAME property, which is where Simplerisk should look for a database. Default value is `localhost`.
+
+### SIMPLERISK_DB_PORT
+
+This will replace the content of the DB_PORT property, which is where Simplerisk will look for a database port  to connect. Default value is `3306`.
+
+### SIMPLERISK_DB_USERNAME
+
+This will replace the content of the DB_USERNAME property, which is the username to be used to connect to the database. Default value is `simplerisk`.
+
+### SIMPLERISK_DB_PASSWORD
+
+This will replace the content of the DB_PASSWORD property, which is the password to be used to connect to the database. Default value is `simplerisk`.
+
+### SIMPLERISK_DB_DATABASE
+
+This will replace the content of the DB_DATABASE property, which is the name of the database to connect. Default value is `simplerisk`.
+
+### SIMPLERISK_DB_FOR_SESSIONS
+
+This will replace the content of the USE_DATABASE_FOR_SESSIONS property, which if marked as true, will store all sessions on the configured database. Default value is `true`. 
+
+### SIMPLERISK_DB_SSL_CERT_PATH
+
+This will replace the content of the DB_SSL_CERTIFICATE_PATH property, which is the path where the SSL certificates to access the database are located. Default is empty (`''`).

--- a/simplerisk-php7.4-apache/app_setup/000-default.conf
+++ b/simplerisk-php7.4-apache/app_setup/000-default.conf
@@ -1,0 +1,5 @@
+<VirtualHost *:80>
+	RewriteEngine On
+	RewriteCond %{HTTPS} !=on
+	RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+</VirtualHost>

--- a/simplerisk-php7.4-apache/app_setup/default-ssl.conf
+++ b/simplerisk-php7.4-apache/app_setup/default-ssl.conf
@@ -1,0 +1,20 @@
+<IfModule mod_ssl.c>
+
+SSLStrictSNIVHostCheck Off
+
+<VirtualHost *:443>
+        DocumentRoot /var/www/simplerisk
+        <Directory "/var/www/simplerisk">
+                AllowOverride all
+                allow from all
+                Options -Indexes
+        </Directory>
+        SSLEngine on
+        SSLCertificateFile    /etc/apache2/ssl/ssl.crt/simplerisk.crt
+        SSLCertificateKeyFile /etc/apache2/ssl/ssl.key/simplerisk.key
+        SSLProtocol TLSv1.2
+        SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown
+        CustomLog /var/log/apache2/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+</VirtualHost>
+
+</IfModule>

--- a/simplerisk-php7.4-apache/app_setup/entrypoint.sh
+++ b/simplerisk-php7.4-apache/app_setup/entrypoint.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -eo pipefail
+
+print_log(){
+    echo "$(date -u +"[%a %b %e %X.%6N %Y]") [$1] $2"
+}
+
+exec_cmd(){
+    exec_cmd_nobail "$1" || fatal_error "$2"
+}
+
+exec_cmd_nobail() {
+    bash -c "$1"
+}
+
+fatal_error(){
+    print_log "error" "$1"
+    exit 1
+}
+
+set_config(){
+    CONFIG_PATH='/var/www/simplerisk/includes/config.php'
+
+    # Replacing config variables if they exist
+    if [ ! -z $SIMPLERISK_DB_HOSTNAME ]; then
+        sed -i "s/\('DB_HOSTNAME', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_HOSTNAME)\2/g" $CONFIG_PATH
+    fi
+    SIMPLERISK_DB_HOSTNAME="${SIMPLERISK_DB_HOSTNAME:-localhost}"
+
+    if [ ! -z $SIMPLERISK_DB_PORT ]; then
+        sed -i "s/\('DB_PORT', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PORT)\2/g" $CONFIG_PATH
+    fi
+    SIMPLERISK_DB_PORT="${SIMPLERISK_DB_PORT:-3306}"
+
+    if [ ! -z $SIMPLERISK_DB_USERNAME ]; then
+        sed -i "s/\('DB_USERNAME', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_USERNAME)\2/g" $CONFIG_PATH
+    fi
+    SIMPLERISK_DB_USERNAME="${SIMPLERISK_DB_USERNAME:-simplerisk}"
+
+    if [ ! -z $FIRST_TIME_SETUP ]; then
+        if [ -z $SIMPLERISK_DB_PASSWORD ]; then
+            SIMPLERISK_DB_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-21})
+            print_log "initial_setup:warn" "As no password was provided and this is a first time setup, a random password has been generated ($(echo $SIMPLERISK_DB_PASSWORD))"
+        fi
+        sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
+    else
+        if [ ! -z $SIMPLERISK_DB_PASSWORD ]; then
+            sed -i "s/\('DB_PASSWORD', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_PASSWORD)\2/g" $CONFIG_PATH
+        fi
+    fi
+    SIMPLERISK_DB_PASSWORD="${SIMPLERISK_DB_PASSWORD:-simplerisk}" 
+
+    if [ ! -z $SIMPLERISK_DB_DATABASE ]; then
+        sed -i "s/\('DB_DATABASE', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_DATABASE)\2/g" $CONFIG_PATH
+    fi
+    SIMPLERISK_DB_DATABASE="${SIMPLERISK_DB_DATABASE:-simplerisk}"
+
+    if [ ! -z $SIMPLERISK_DB_FOR_SESSIONS ]; then
+        sed -i "s/\('USE_DATABASE_FOR_SESSIONS', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_FOR_SESSIONS)\2/g" $CONFIG_PATH
+    fi
+
+    if [ ! -z $SIMPLERISK_DB_SSL_CERT_PATH ]; then
+        sed -i "s/\('DB_SSL_CERTIFICATE_PATH', '\).*\(');\)/\1$(echo $SIMPLERISK_DB_SSL_CERT_PATH)\2/g" $CONFIG_PATH
+    fi
+}
+
+db_setup(){
+    print_log "initial_setup:info" "First time setup. Will wait..."
+    exec_cmd "sleep $(echo ${FIRST_TIME_SETUP_WAIT:-2O})s > /dev/null 2>&1" "FIRST_TIME_SETUP_WAIT variable is set incorrectly. Exiting."
+
+    print_log "initial_setup:info" "Starting database set up"
+
+    print_log "initial_setup:info" "Downloading schema..."
+    SCHEMA_FILE='/tmp/simplerisk.sql'
+    exec_cmd "curl -sL https://github.com/simplerisk/database/raw/master/simplerisk-en-$(cat /tmp/version).sql > $SCHEMA_FILE" "Could not download schema from Github. Exiting."
+
+    FIRST_TIME_SETUP_USER="${FIRST_TIME_SETUP_USER:-root}"
+    FIRST_TIME_SETUP_PASS="${FIRST_TIME_SETUP_PASS:-root}"
+
+    print_log "initial_setup:info" "Applying changes to MySQL database... (MySQL error will be printed to console as guidance)"
+    exec_cmd "mysql --protocol=socket -u $FIRST_TIME_SETUP_USER -p$FIRST_TIME_SETUP_PASS -h$SIMPLERISK_DB_HOSTNAME -P$SIMPLERISK_DB_PORT <<EOSQL
+    CREATE DATABASE ${SIMPLERISK_DB_DATABASE};
+    USE ${SIMPLERISK_DB_DATABASE};
+    \. ${SCHEMA_FILE}
+    CREATE USER ${SIMPLERISK_DB_USERNAME}@'%' IDENTIFIED BY '${SIMPLERISK_DB_PASSWORD}';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON ${SIMPLERISK_DB_DATABASE}.* TO ${SIMPLERISK_DB_USERNAME}@'%';
+EOSQL" "Was not able to apply settings on database. Check error above. Exiting."
+
+    print_log "initial_setup:info" "Setup has been applied successfully!"
+    print_log "initial_setup:info" "Removing schema file..."
+    exec_cmd "rm ${SCHEMA_FILE}"
+
+    if [ ! -z $FIRST_TIME_SETUP_ONLY ]; then
+        print_log "initial_setup:info" "Running on setup only. Container will be discarded."
+        exit 0
+    fi
+}
+
+unset_variables() {
+    unset FIRST_TIME_SETUP
+    unset FIRST_TIME_SETUP_ONLY
+    unset FIRST_TIME_SETUP_USER
+    unset FIRST_TIME_SETUP_PASS
+    unset FIRST_TIME_SETUP_WAIT
+    unset SIMPLERISK_DB_HOSTNAME
+    unset SIMPLERISK_DB_PORT
+    unset SIMPLERISK_DB_USERNAME
+    unset SIMPLERISK_DB_PASSWORD
+    unset SIMPLERISK_DB_DATABASE
+    unset SIMPLERISK_DB_FOR_SESSIONS
+    unset SIMPLERISK_DB_SSL_CERT_PATH
+}
+
+_main() {
+    set_config
+    if [ ! -z $FIRST_TIME_SETUP ]; then
+      db_setup
+    fi
+    unset_variables
+    exec "$@"
+}
+
+_main "$@"

--- a/simplerisk-php7.4-apache/app_setup/envvars
+++ b/simplerisk-php7.4-apache/app_setup/envvars
@@ -1,0 +1,37 @@
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+	SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+	SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER=simplerisk
+export APACHE_RUN_GROUP=www-data
+export APACHE_PID_FILE=/var/run/apache2$SUFFIX.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'

--- a/simplerisk-php7.4-apache/app_setup/foreground.sh
+++ b/simplerisk-php7.4-apache/app_setup/foreground.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+read pid cmd state ppid pgrp session tty_nr tpgid rest < /proc/self/stat
+trap "kill -TERM -$pgrp; exit" EXIT TERM SIGTERM SIGQUIT
+
+
+source /etc/apache2/envvars
+apache2 -D FOREGROUND

--- a/simplerisk-php7.4-apache/app_setup/supervisord.conf
+++ b/simplerisk-php7.4-apache/app_setup/supervisord.conf
@@ -1,0 +1,149 @@
+; Sample supervisor config file.
+;
+; For more information on the config file, please see:
+; http://supervisord.org/configuration.html
+;
+; Note: shell expansion ("~" or "$HOME") is not supported.  Environment
+; variables can be expanded using this syntax: "%(ENV_HOME)s".
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; (the path to the socket file)
+;chmod=0700                 ; socket file mode (default 0700)
+;chown=nobody:nogroup       ; socket file uid:gid owner
+;username=user              ; (default is no username (open server))
+;password=123               ; (default is no password (open server))
+
+;[inet_http_server]         ; inet (TCP) server disabled by default
+;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
+;username=user              ; (default is no username (open server))
+;password=123               ; (default is no password (open server))
+
+[supervisord]
+logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=10           ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=false               ; (start in foreground if true;default false)
+minfds=1024                  ; (min. avail startup file descriptors;default 1024)
+minprocs=200                 ; (min. avail process descriptors;default 200)
+;umask=022                   ; (process file creation umask;default 022)
+;user=chrism                 ; (default is current user, required if root)
+;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
+;directory=/tmp              ; (default is not to cd during start)
+;nocleanup=true              ; (don't clean up tempfiles at start;default false)
+;childlogdir=/tmp            ; ('AUTO' child log dir, default $TEMP)
+;environment=KEY=value       ; (key value pairs to add to environment)
+;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+;username=chris              ; should be same as http_username if set
+;password=123                ; should be same as http_password if set
+;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
+;history_file=~/.sc_history  ; use readline history if available
+
+; The below sample program section shows all possible program subsection values,
+; create one or more 'real' program: sections to be able to control them under
+; supervisor.
+
+;[program:theprogramname]
+;command=/bin/cat              ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=999                  ; the relative start priority (default 999)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
+;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions (def no adds)
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample eventlistener section shows all possible
+; eventlistener subsection values, create one or more 'real'
+; eventlistener: sections to be able to handle event notifications
+; sent by supervisor.
+
+;[eventlistener:theeventlistenername]
+;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;events=EVENT                  ; event notif. types to subscribe to (req'd)
+;buffer_size=10                ; event buffer queue size (default 10)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=-1                   ; the relative start priority (default -1)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups        ; # of stderr logfile backups (default 10)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample group section shows all possible group values,
+; create one or more 'real' group: sections to create "heterogeneous"
+; process groups.
+
+;[group:thegroupname]
+;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
+;priority=999                  ; the relative start priority (default 999)
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+;[include]
+;files = relative/directory/*.ini
+;mysql and apache2
+[program:httpd]
+command=/etc/apache2/foreground.sh
+stopsignal=6
+;sshd 
+;[program:sshd]
+;command=/usr/sbin/sshd -D
+;stdout_logfile=/var/log/supervisor/%(program_name)s.log
+;stderr_logfile=/var/log/supervisor/%(program_name)s.log
+;autorestart=true


### PR DESCRIPTION
This image has the following goals:
- Uses the most updated and stable version of PHP to date (7.4)
- Installs the `libonig-dev` library to install mbstring
- Currently has no sendmail installed, to keep it as minimal as possible
  - On the docker-compose.yml, a SMTP server (namshi/smtp) is set up, so the user must include the necessary information to use it as a relay. It was tested with Gmail and worked successfully.
- Removed code that was considered vulnerable by the shiftleft/scan SAST.