### PR TITLE
Fixing start.sh script for Simplerisk

### DIFF
--- a/simplerisk/common/start.sh
+++ b/simplerisk/common/start.sh
@@ -16,12 +16,8 @@ if [ ! -f /configurations/mysql-configured ]; then
 	mysql -uroot -p`cat /passwords/pass_mysql_root.txt` -e "use simplerisk; \. /simplerisk.sql"
 
 	# Set the permissions for th4e SimpleRisk database
-	if [ $(. /etc/os-release && echo $VERSION_CODENAME) == 'focal' ]; then
-		mysql -uroot -p`cat /passwords/pass_mysql_root.txt` -e "CREATE USER 'simplerisk'@'localhost' IDENTIFIED BY '`cat /passwords/pass_simplerisk.txt`'"
-		mysql -uroot -p`cat /passwords/pass_mysql_root.txt` -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON simplerisk.* TO 'simplerisk'@'localhost'"
-	else
-		mysql -uroot -p`cat /passwords/pass_mysql_root.txt` -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON simplerisk.* TO 'simplerisk'@'localhost' IDENTIFIED BY '`cat /passwords/pass_simplerisk.txt`'"
-	fi
+	mysql -uroot -p`cat /passwords/pass_mysql_root.txt` -e "CREATE USER 'simplerisk'@'localhost' IDENTIFIED BY '`cat /passwords/pass_simplerisk.txt`'"
+	mysql -uroot -p`cat /passwords/pass_mysql_root.txt` -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER ON simplerisk.* TO 'simplerisk'@'localhost'"
 
 	# Create a file so this doesn't run again
 	touch /configurations/mysql-configured


### PR DESCRIPTION
As of version 20.04, the installed MySQL does not accept to create an user and grant permissions to it on the same line.

As the fix also works for the previous version (18.04), it is not necessary to check what OS version is being used.