### PR TITLE
Shellcheck implementation and minor fixes

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,18 @@
+name: Shell script checkup with ShellCheck
+
+on:
+  pull_request:
+    branch:
+      - master
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code 
+      uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+          severity: error 

--- a/simplerisk/common/foreground.sh
+++ b/simplerisk/common/foreground.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 read pid cmd state ppid pgrp session tty_nr tpgid rest < /proc/self/stat
-trap "kill -TERM -$pgrp; exit" EXIT TERM KILL SIGKILL SIGTERM SIGQUIT
+trap "kill -TERM -$pgrp; exit" EXIT TERM SIGTERM SIGQUIT
 
 
 source /etc/apache2/envvars


### PR DESCRIPTION
Implemented Shellcheck to check scripts being used.

As part of this check, the SIGKILL and KILL signals being used on `foreground.sh` have been removed.